### PR TITLE
Option to give different paths for different types of files

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,0 +1,54 @@
+name: Core Tests
+on: [push, pull_request]
+jobs:
+  tests:
+    name: Core Tests
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-18.04]
+        # TODO: python 2.6
+        python-version: [2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, pypy-2.7, pypy-3.6, pypy-3.7]
+        python-impl: [cpython]
+        ytdl-test-set: [core]
+        run-tests-ext: [sh]
+        include:
+        # python 3.2 is only available on windows via setup-python
+        - os: windows-latest
+          python-version: 3.2
+          python-impl: cpython
+          ytdl-test-set: core
+          run-tests-ext: bat
+        # jython
+        - os: ubuntu-latest
+          python-impl: jython
+          ytdl-test-set: core
+          run-tests-ext: sh
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      if: ${{ matrix.python-impl == 'cpython' }}
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up Java 8
+      if: ${{ matrix.python-impl == 'jython' }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Install Jython
+      if: ${{ matrix.python-impl == 'jython' }}
+      run: |
+        wget http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.1/jython-installer-2.7.1.jar -O jython-installer.jar
+        java -jar jython-installer.jar -s -d "$HOME/jython"
+        echo "$HOME/jython/bin" >> $GITHUB_PATH
+    - name: Install nose
+      run: pip install nose
+    - name: Run tests
+      continue-on-error: ${{ matrix.ytdl-test-set == 'download' || matrix.python-impl == 'jython' }}
+      env:
+        YTDL_TEST_SET: ${{ matrix.ytdl-test-set }}
+      run: ./devscripts/run_tests.${{ matrix.run-tests-ext }}
+  # Linter is in quick-test

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -1,9 +1,9 @@
-name: Full Test
+name: Download Tests
 on: [push, pull_request]
 jobs:
   tests:
-    name: Tests
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Download Tests
+    if: "!contains(github.event.head_commit.message, 'ci skip dl') || !contains(github.event.head_commit.message, 'ci skip all')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -12,29 +12,20 @@ jobs:
         # TODO: python 2.6
         python-version: [2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, pypy-2.7, pypy-3.6, pypy-3.7]
         python-impl: [cpython]
-        ytdl-test-set: [core, download]
+        ytdl-test-set: [download]
         run-tests-ext: [sh]
         include:
         # python 3.2 is only available on windows via setup-python
         - os: windows-latest
           python-version: 3.2
           python-impl: cpython
-          ytdl-test-set: core
-          run-tests-ext: bat
-        - os: windows-latest
-          python-version: 3.2
-          python-impl: cpython
           ytdl-test-set: download
           run-tests-ext: bat
-        # jython
-        - os: ubuntu-latest
-          python-impl: jython
-          ytdl-test-set: core
-          run-tests-ext: sh
-        - os: ubuntu-latest
-          python-impl: jython
-          ytdl-test-set: download
-          run-tests-ext: sh
+        # jython - disable for now since it takes too long to complete
+        # - os: ubuntu-latest
+        #   python-impl: jython
+        #   ytdl-test-set: download
+        #   run-tests-ext: sh
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -60,4 +51,3 @@ jobs:
       env:
         YTDL_TEST_SET: ${{ matrix.ytdl-test-set }}
       run: ./devscripts/run_tests.${{ matrix.run-tests-ext }}
-  # flake8 has been moved to quick-test

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -1,13 +1,13 @@
-name: Core Test
+name: Quick Test
 on: [push, pull_request]
 jobs:
   tests:
     name: Core Tests
-    if: "!contains(github.event.head_commit.message, 'skip ci all')"
+    if: "!contains(github.event.head_commit.message, 'ci skip all')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
@@ -19,7 +19,7 @@ jobs:
       run: ./devscripts/run_tests.sh
   flake8:
     name: Linter
-    if: "!contains(github.event.head_commit.message, 'skip ci all')"
+    if: "!contains(github.event.head_commit.message, 'ci skip all')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -660,8 +660,8 @@ Then simply type this
 You can configure youtube-dlc by placing any supported command line option to a configuration file. The configuration is loaded from the following locations:
 
 1. **Main Configuration**: The file given by `--config-location`
-1. **Home Configuration**: `yt-dlp.conf` or `youtube-dlc.conf` in the home path given by `-P "home:<path>"`, or in the current directory if no such path is given
 1. **Portable Configuration**: `yt-dlp.conf` or `youtube-dlc.conf` in the same directory as the bundled binary. If you are running from source-code (`<root dir>/youtube_dlc/__main__.py`), the root directory is used instead.
+1. **Home Configuration**: `yt-dlp.conf` or `youtube-dlc.conf` in the home path given by `-P "home:<path>"`, or in the current directory if no such path is given
 1. **User Configuration**:
     * `%XDG_CONFIG_HOME%/yt-dlp/config` (recommended on Linux/macOS)
     * `%XDG_CONFIG_HOME%/yt-dlp.conf`

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <!-- See: https://github.com/marketplace/actions/dynamic-badges -->
 [![Release Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/pukkandan/c69cb23c3c5b3316248e52022790aa57/raw/version.json&color=brightgreen)](https://github.com/pukkandan/yt-dlp/releases/latest)
 [![License: Unlicense](https://img.shields.io/badge/License-Unlicense-blue.svg)](https://github.com/pukkandan/yt-dlp/blob/master/LICENSE)
-[![Core Status](https://github.com/pukkandan/yt-dlp/workflows/Core%20Test/badge.svg?branch=master)](https://github.com/pukkandan/yt-dlp/actions?query=workflow%3ACore)
-[![CI Status](https://github.com/pukkandan/yt-dlp/workflows/Full%20Test/badge.svg?branch=master)](https://github.com/pukkandan/yt-dlp/actions?query=workflow%3AFull)
+[![CI Status](https://github.com/pukkandan/yt-dlp/workflows/Core%20Tests/badge.svg?branch=master)](https://github.com/pukkandan/yt-dlp/actions)
 
 A command-line program to download videos from youtube.com and many other [video platforms](docs/supportedsites.md)
 
@@ -303,11 +302,14 @@ Then simply type this
                                      allowing to play the video while
                                      downloading (some players may not be able
                                      to play it)
-    --external-downloader COMMAND    Use the specified external downloader.
-                                     Currently supports
-                                     aria2c,avconv,axel,curl,ffmpeg,httpie,wget
-    --external-downloader-args ARGS  Give these arguments to the external
-                                     downloader
+    --external-downloader NAME       Use the specified external downloader.
+                                     Currently supports aria2c, avconv, axel,
+                                     curl, ffmpeg, httpie, wget
+    --downloader-args NAME:ARGS      Give these arguments to the external
+                                     downloader. Specify the downloader name and
+                                     the arguments separated by a colon ":". You
+                                     can use this option multiple times (Alias:
+                                     --external-downloader-args)
 
 ## Filesystem Options:
     -a, --batch-file FILE            File containing URLs to download ('-' for
@@ -446,7 +448,7 @@ Then simply type this
     --referer URL                    Specify a custom referer, use if the video
                                      access is restricted to one domain
     --add-header FIELD:VALUE         Specify a custom HTTP header and its value,
-                                     separated by a colon ':'. You can use this
+                                     separated by a colon ":". You can use this
                                      option multiple times
     --bidi-workaround                Work around terminals that lack
                                      bidirectional text support. Requires bidiv
@@ -566,7 +568,7 @@ Then simply type this
     --postprocessor-args NAME:ARGS   Give these arguments to the postprocessors.
                                      Specify the postprocessor/executable name
                                      and the arguments separated by a colon ":"
-                                     to give the argument to only the specified
+                                     to give the argument to the specified
                                      postprocessor/executable. Supported
                                      postprocessors are: SponSkrub,
                                      ExtractAudio, VideoRemuxer, VideoConvertor,
@@ -580,7 +582,8 @@ Then simply type this
                                      to different postprocessors. You can also
                                      specify "PP+EXE:ARGS" to give the arguments
                                      to the specified executable only when being
-                                     used by the specified postprocessor (Alias:
+                                     used by the specified postprocessor. You
+                                     can use this option multiple times (Alias:
                                      --ppa)
     -k, --keep-video                 Keep the intermediate video file on disk
                                      after post-processing

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Then simply type this
                                      compatibility) if this option is found
                                      inside the system configuration file, the
                                      user configuration is not loaded
-    --config-location PATH           Location of the configuration file; either
-                                     the path to the config or its containing
-                                     directory
+    --config-location PATH           Location of the main configuration file;
+                                     either the path to the config or its
+                                     containing directory
     --flat-playlist                  Do not extract the videos of a playlist,
                                      only list them
     --flat-videos                    Do not resolve the video urls

--- a/README.md
+++ b/README.md
@@ -314,6 +314,17 @@ Then simply type this
                                      stdin), one URL per line. Lines starting
                                      with '#', ';' or ']' are considered as
                                      comments and ignored
+    -P, --paths TYPE:PATH            The paths where the files should be
+                                     downloaded. Specify the type of file and
+                                     the path separated by a colon ":"
+                                     (supported: description|annotation|subtitle
+                                     |infojson|thumbnail). Additionally, you can
+                                     also provide "home" and "temp" paths. All
+                                     intermediary files are first downloaded to
+                                     the temp path and then the final files are
+                                     moved over to the home path after download
+                                     is finished. Note that this option is
+                                     ignored if --output is an absolute path
     -o, --output TEMPLATE            Output filename template, see "OUTPUT
                                      TEMPLATE" for details
     --autonumber-start NUMBER        Specify the start value for %(autonumber)s
@@ -554,7 +565,7 @@ Then simply type this
                                      supported: mp4|flv|ogg|webm|mkv|avi)
     --postprocessor-args NAME:ARGS   Give these arguments to the postprocessors.
                                      Specify the postprocessor/executable name
-                                     and the arguments separated by a colon ':'
+                                     and the arguments separated by a colon ":"
                                      to give the argument to only the specified
                                      postprocessor/executable. Supported
                                      postprocessors are: SponSkrub,
@@ -648,7 +659,8 @@ Then simply type this
 
 You can configure youtube-dlc by placing any supported command line option to a configuration file. The configuration is loaded from the following locations:
 
-1. The file given by `--config-location`
+1. **Main Configuration**: The file given by `--config-location`
+1. **Home Configuration**: `yt-dlp.conf` or `youtube-dlc.conf` in the home path given by `-P "home:<path>"`, or in the current directory if no such path is given
 1. **Portable Configuration**: `yt-dlp.conf` or `youtube-dlc.conf` in the same directory as the bundled binary. If you are running from source-code (`<root dir>/youtube_dlc/__main__.py`), the root directory is used instead.
 1. **User Configuration**:
     * `%XDG_CONFIG_HOME%/yt-dlp/config` (recommended on Linux/macOS)
@@ -707,7 +719,7 @@ set HOME=%USERPROFILE%
 
 # OUTPUT TEMPLATE
 
-The `-o` option allows users to indicate a template for the output file names.
+The `-o` option is used to indicate a template for the output file names while `-P` option is used to specify the path each type of file should be saved to.
 
 **tl;dr:** [navigate me to examples](#output-template-examples).
 

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -69,6 +69,7 @@ from .utils import (
     iri_to_uri,
     ISO3166Utils,
     locked_file,
+    make_dir,
     make_HTTPS_handler,
     MaxDownloadsReached,
     orderedSet,
@@ -114,8 +115,9 @@ from .postprocessor import (
     FFmpegFixupStretchedPP,
     FFmpegMergerPP,
     FFmpegPostProcessor,
-    FFmpegSubtitlesConvertorPP,
+    # FFmpegSubtitlesConvertorPP,
     get_postprocessor,
+    MoveFilesAfterDownloadPP,
 )
 from .version import __version__
 
@@ -257,6 +259,8 @@ class YoutubeDL(object):
     postprocessors:    A list of dictionaries, each with an entry
                        * key:  The name of the postprocessor. See
                                youtube_dlc/postprocessor/__init__.py for a list.
+                       * _after_move: Optional. If True, run this post_processor
+                               after 'MoveFilesAfterDownload'
                        as well as any further keyword arguments for the
                        postprocessor.
     post_hooks:        A list of functions that get called as the final step
@@ -369,6 +373,8 @@ class YoutubeDL(object):
     params = None
     _ies = []
     _pps = []
+    _pps_end = []
+    __prepare_filename_warned = False
     _download_retcode = None
     _num_downloads = None
     _playlist_level = 0
@@ -382,6 +388,7 @@ class YoutubeDL(object):
         self._ies = []
         self._ies_instances = {}
         self._pps = []
+        self._pps_end = []
         self._post_hooks = []
         self._progress_hooks = []
         self._download_retcode = 0
@@ -483,8 +490,11 @@ class YoutubeDL(object):
             pp_class = get_postprocessor(pp_def_raw['key'])
             pp_def = dict(pp_def_raw)
             del pp_def['key']
+            after_move = pp_def.get('_after_move', False)
+            if '_after_move' in pp_def:
+                del pp_def['_after_move']
             pp = pp_class(self, **compat_kwargs(pp_def))
-            self.add_post_processor(pp)
+            self.add_post_processor(pp, after_move=after_move)
 
         for ph in self.params.get('post_hooks', []):
             self.add_post_hook(ph)
@@ -536,9 +546,12 @@ class YoutubeDL(object):
         for ie in gen_extractor_classes():
             self.add_info_extractor(ie)
 
-    def add_post_processor(self, pp):
+    def add_post_processor(self, pp, after_move=False):
         """Add a PostProcessor object to the end of the chain."""
-        self._pps.append(pp)
+        if after_move:
+            self._pps_end.append(pp)
+        else:
+            self._pps.append(pp)
         pp.set_downloader(self)
 
     def add_post_hook(self, ph):
@@ -702,7 +715,7 @@ class YoutubeDL(object):
         except UnicodeEncodeError:
             self.to_screen('Deleting already existent file')
 
-    def prepare_filename(self, info_dict):
+    def prepare_filename(self, info_dict, warn=False):
         """Generate the output filename."""
         try:
             template_dict = dict(info_dict)
@@ -796,10 +809,32 @@ class YoutubeDL(object):
             # to workaround encoding issues with subprocess on python2 @ Windows
             if sys.version_info < (3, 0) and sys.platform == 'win32':
                 filename = encodeFilename(filename, True).decode(preferredencoding())
-            return sanitize_path(filename)
+            filename = sanitize_path(filename)
+
+            if warn and not self.__prepare_filename_warned:
+                if not self.params.get('paths'):
+                    pass
+                elif filename == '-':
+                    self.report_warning('--paths is ignored when an outputting to stdout')
+                elif os.path.isabs(filename):
+                    self.report_warning('--paths is ignored since an absolute path is given in output template')
+                self.__prepare_filename_warned = True
+
+            return filename
         except ValueError as err:
             self.report_error('Error in output template: ' + str(err) + ' (encoding: ' + repr(preferredencoding()) + ')')
             return None
+
+    def prepare_filepath(self, filename, dir_type=''):
+        if filename == '-':
+            return filename
+        paths = self.params.get('paths', {})
+        assert isinstance(paths, dict)
+        homepath = expand_path(paths.get('home', '').strip())
+        assert isinstance(homepath, compat_str)
+        subdir = expand_path(paths.get(dir_type, '').strip()) if dir_type else ''
+        assert isinstance(subdir, compat_str)
+        return sanitize_path(os.path.join(homepath, subdir, filename))
 
     def _match_entry(self, info_dict, incomplete):
         """ Returns None if the file should be downloaded """
@@ -972,7 +1007,8 @@ class YoutubeDL(object):
             if ((extract_flat == 'in_playlist' and 'playlist' in extra_info)
                     or extract_flat is True):
                 self.__forced_printings(
-                    ie_result, self.prepare_filename(ie_result),
+                    ie_result,
+                    self.prepare_filepath(self.prepare_filename(ie_result)),
                     incomplete=True)
                 return ie_result
 
@@ -1890,6 +1926,8 @@ class YoutubeDL(object):
 
         assert info_dict.get('_type', 'video') == 'video'
 
+        info_dict.setdefault('__postprocessors', [])
+
         max_downloads = self.params.get('max_downloads')
         if max_downloads is not None:
             if self._num_downloads >= int(max_downloads):
@@ -1906,10 +1944,13 @@ class YoutubeDL(object):
 
         self._num_downloads += 1
 
-        info_dict['_filename'] = filename = self.prepare_filename(info_dict)
+        filename = self.prepare_filename(info_dict, warn=True)
+        info_dict['_filename'] = full_filename = self.prepare_filepath(filename)
+        temp_filename = self.prepare_filepath(filename, 'temp')
+        files_to_move = {}
 
         # Forced printings
-        self.__forced_printings(info_dict, filename, incomplete=False)
+        self.__forced_printings(info_dict, full_filename, incomplete=False)
 
         if self.params.get('simulate', False):
             if self.params.get('force_write_download_archive', False):
@@ -1922,20 +1963,19 @@ class YoutubeDL(object):
             return
 
         def ensure_dir_exists(path):
-            try:
-                dn = os.path.dirname(path)
-                if dn and not os.path.exists(dn):
-                    os.makedirs(dn)
-                return True
-            except (OSError, IOError) as err:
-                self.report_error('unable to create directory ' + error_to_compat_str(err))
-                return False
+            return make_dir(path, self.report_error)
 
-        if not ensure_dir_exists(sanitize_path(encodeFilename(filename))):
+        if not ensure_dir_exists(encodeFilename(full_filename)):
+            return
+        if not ensure_dir_exists(encodeFilename(temp_filename)):
             return
 
         if self.params.get('writedescription', False):
-            descfn = replace_extension(filename, 'description', info_dict.get('ext'))
+            descfn = replace_extension(
+                self.prepare_filepath(filename, 'description'),
+                'description', info_dict.get('ext'))
+            if not ensure_dir_exists(encodeFilename(descfn)):
+                return
             if not self.params.get('overwrites', True) and os.path.exists(encodeFilename(descfn)):
                 self.to_screen('[info] Video description is already present')
             elif info_dict.get('description') is None:
@@ -1950,7 +1990,11 @@ class YoutubeDL(object):
                     return
 
         if self.params.get('writeannotations', False):
-            annofn = replace_extension(filename, 'annotations.xml', info_dict.get('ext'))
+            annofn = replace_extension(
+                self.prepare_filepath(filename, 'annotation'),
+                'annotations.xml', info_dict.get('ext'))
+            if not ensure_dir_exists(encodeFilename(annofn)):
+                return
             if not self.params.get('overwrites', True) and os.path.exists(encodeFilename(annofn)):
                 self.to_screen('[info] Video annotations are already present')
             elif not info_dict.get('annotations'):
@@ -1984,9 +2028,13 @@ class YoutubeDL(object):
             # ie = self.get_info_extractor(info_dict['extractor_key'])
             for sub_lang, sub_info in subtitles.items():
                 sub_format = sub_info['ext']
-                sub_filename = subtitles_filename(filename, sub_lang, sub_format, info_dict.get('ext'))
+                sub_filename = subtitles_filename(temp_filename, sub_lang, sub_format, info_dict.get('ext'))
+                sub_filename_final = subtitles_filename(
+                    self.prepare_filepath(filename, 'subtitle'),
+                    sub_lang, sub_format, info_dict.get('ext'))
                 if not self.params.get('overwrites', True) and os.path.exists(encodeFilename(sub_filename)):
                     self.to_screen('[info] Video subtitle %s.%s is already present' % (sub_lang, sub_format))
+                    files_to_move[sub_filename] = sub_filename_final
                 else:
                     self.to_screen('[info] Writing video subtitles to: ' + sub_filename)
                     if sub_info.get('data') is not None:
@@ -1995,6 +2043,7 @@ class YoutubeDL(object):
                             # See https://github.com/ytdl-org/youtube-dl/issues/10268
                             with io.open(encodeFilename(sub_filename), 'w', encoding='utf-8', newline='') as subfile:
                                 subfile.write(sub_info['data'])
+                            files_to_move[sub_filename] = sub_filename_final
                         except (OSError, IOError):
                             self.report_error('Cannot write subtitles file ' + sub_filename)
                             return
@@ -2010,6 +2059,7 @@ class YoutubeDL(object):
                                 with io.open(encodeFilename(sub_filename), 'wb') as subfile:
                                     subfile.write(sub_data)
                             '''
+                            files_to_move[sub_filename] = sub_filename_final
                         except (ExtractorError, IOError, OSError, ValueError, compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                             self.report_warning('Unable to download subtitle for "%s": %s' %
                                                 (sub_lang, error_to_compat_str(err)))
@@ -2017,29 +2067,32 @@ class YoutubeDL(object):
 
         if self.params.get('skip_download', False):
             if self.params.get('convertsubtitles', False):
-                subconv = FFmpegSubtitlesConvertorPP(self, format=self.params.get('convertsubtitles'))
+                # subconv = FFmpegSubtitlesConvertorPP(self, format=self.params.get('convertsubtitles'))
                 filename_real_ext = os.path.splitext(filename)[1][1:]
                 filename_wo_ext = (
-                    os.path.splitext(filename)[0]
+                    os.path.splitext(full_filename)[0]
                     if filename_real_ext == info_dict['ext']
-                    else filename)
+                    else full_filename)
                 afilename = '%s.%s' % (filename_wo_ext, self.params.get('convertsubtitles'))
-                if subconv.available:
-                    info_dict.setdefault('__postprocessors', [])
-                    # info_dict['__postprocessors'].append(subconv)
+                # if subconv.available:
+                #     info_dict['__postprocessors'].append(subconv)
                 if os.path.exists(encodeFilename(afilename)):
                     self.to_screen(
                         '[download] %s has already been downloaded and '
                         'converted' % afilename)
                 else:
                     try:
-                        self.post_process(filename, info_dict)
+                        self.post_process(full_filename, info_dict, files_to_move)
                     except (PostProcessingError) as err:
                         self.report_error('postprocessing: %s' % str(err))
                         return
 
         if self.params.get('writeinfojson', False):
-            infofn = replace_extension(filename, 'info.json', info_dict.get('ext'))
+            infofn = replace_extension(
+                self.prepare_filepath(filename, 'infojson'),
+                'info.json', info_dict.get('ext'))
+            if not ensure_dir_exists(encodeFilename(infofn)):
+                return
             if not self.params.get('overwrites', True) and os.path.exists(encodeFilename(infofn)):
                 self.to_screen('[info] Video description metadata is already present')
             else:
@@ -2050,7 +2103,9 @@ class YoutubeDL(object):
                     self.report_error('Cannot write metadata to JSON file ' + infofn)
                     return
 
-        self._write_thumbnails(info_dict, filename)
+        thumbdir = os.path.dirname(self.prepare_filepath(filename, 'thumbnail'))
+        for thumbfn in self._write_thumbnails(info_dict, temp_filename):
+            files_to_move[thumbfn] = os.path.join(thumbdir, os.path.basename(thumbfn))
 
         # Write internet shortcut files
         url_link = webloc_link = desktop_link = False
@@ -2075,7 +2130,7 @@ class YoutubeDL(object):
             ascii_url = iri_to_uri(info_dict['webpage_url'])
 
         def _write_link_file(extension, template, newline, embed_filename):
-            linkfn = replace_extension(filename, extension, info_dict.get('ext'))
+            linkfn = replace_extension(full_filename, extension, info_dict.get('ext'))
             if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(linkfn)):
                 self.to_screen('[info] Internet shortcut is already present')
             else:
@@ -2105,9 +2160,27 @@ class YoutubeDL(object):
         must_record_download_archive = False
         if not self.params.get('skip_download', False):
             try:
+
+                def existing_file(filename, temp_filename):
+                    file_exists = os.path.exists(encodeFilename(filename))
+                    tempfile_exists = (
+                        False if temp_filename == filename
+                        else os.path.exists(encodeFilename(temp_filename)))
+                    if not self.params.get('overwrites', False) and (file_exists or tempfile_exists):
+                        existing_filename = temp_filename if tempfile_exists else filename
+                        self.to_screen('[download] %s has already been downloaded and merged' % existing_filename)
+                        return existing_filename
+                    if tempfile_exists:
+                        self.report_file_delete(temp_filename)
+                        os.remove(encodeFilename(temp_filename))
+                    if file_exists:
+                        self.report_file_delete(filename)
+                        os.remove(encodeFilename(filename))
+                    return None
+
+                success = True
                 if info_dict.get('requested_formats') is not None:
                     downloaded = []
-                    success = True
                     merger = FFmpegMergerPP(self)
                     if not merger.available:
                         postprocessors = []
@@ -2136,32 +2209,32 @@ class YoutubeDL(object):
                         # TODO: Check acodec/vcodec
                         return False
 
-                    filename_real_ext = os.path.splitext(filename)[1][1:]
-                    filename_wo_ext = (
-                        os.path.splitext(filename)[0]
-                        if filename_real_ext == info_dict['ext']
-                        else filename)
                     requested_formats = info_dict['requested_formats']
+                    old_ext = info_dict['ext']
                     if self.params.get('merge_output_format') is None and not compatible_formats(requested_formats):
                         info_dict['ext'] = 'mkv'
                         self.report_warning(
                             'Requested formats are incompatible for merge and will be merged into mkv.')
+
+                    def correct_ext(filename):
+                        filename_real_ext = os.path.splitext(filename)[1][1:]
+                        filename_wo_ext = (
+                            os.path.splitext(filename)[0]
+                            if filename_real_ext == old_ext
+                            else filename)
+                        print(filename, filename_real_ext, filename_wo_ext, info_dict['ext'])
+                        return '%s.%s' % (filename_wo_ext, info_dict['ext'])
+
                     # Ensure filename always has a correct extension for successful merge
-                    filename = '%s.%s' % (filename_wo_ext, info_dict['ext'])
-                    file_exists = os.path.exists(encodeFilename(filename))
-                    if not self.params.get('overwrites', False) and file_exists:
-                        self.to_screen(
-                            '[download] %s has already been downloaded and '
-                            'merged' % filename)
-                    else:
-                        if file_exists:
-                            self.report_file_delete(filename)
-                            os.remove(encodeFilename(filename))
+                    full_filename = correct_ext(full_filename)
+                    temp_filename = correct_ext(temp_filename)
+                    dl_filename = existing_file(full_filename, temp_filename)
+                    if dl_filename is None:
                         for f in requested_formats:
                             new_info = dict(info_dict)
                             new_info.update(f)
                             fname = prepend_extension(
-                                self.prepare_filename(new_info),
+                                self.prepare_filepath(self.prepare_filename(new_info), 'temp'),
                                 'f%s' % f['format_id'], new_info['ext'])
                             if not ensure_dir_exists(fname):
                                 return
@@ -2173,14 +2246,17 @@ class YoutubeDL(object):
                         # Even if there were no downloads, it is being merged only now
                         info_dict['__real_download'] = True
                 else:
-                    # Delete existing file with --yes-overwrites
-                    if self.params.get('overwrites', False):
-                        if os.path.exists(encodeFilename(filename)):
-                            self.report_file_delete(filename)
-                            os.remove(encodeFilename(filename))
                     # Just a single file
-                    success, real_download = dl(filename, info_dict)
-                    info_dict['__real_download'] = real_download
+                    dl_filename = existing_file(full_filename, temp_filename)
+                    if dl_filename is None:
+                        success, real_download = dl(temp_filename, info_dict)
+                        info_dict['__real_download'] = real_download
+
+                # info_dict['__temp_filename'] = temp_filename
+                dl_filename = dl_filename or temp_filename
+                info_dict['__dl_filename'] = dl_filename
+                info_dict['__final_filename'] = full_filename
+
             except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                 self.report_error('unable to download video data: %s' % error_to_compat_str(err))
                 return
@@ -2206,7 +2282,6 @@ class YoutubeDL(object):
                     elif fixup_policy == 'detect_or_warn':
                         stretched_pp = FFmpegFixupStretchedPP(self)
                         if stretched_pp.available:
-                            info_dict.setdefault('__postprocessors', [])
                             info_dict['__postprocessors'].append(stretched_pp)
                         else:
                             self.report_warning(
@@ -2225,7 +2300,6 @@ class YoutubeDL(object):
                     elif fixup_policy == 'detect_or_warn':
                         fixup_pp = FFmpegFixupM4aPP(self)
                         if fixup_pp.available:
-                            info_dict.setdefault('__postprocessors', [])
                             info_dict['__postprocessors'].append(fixup_pp)
                         else:
                             self.report_warning(
@@ -2244,7 +2318,6 @@ class YoutubeDL(object):
                     elif fixup_policy == 'detect_or_warn':
                         fixup_pp = FFmpegFixupM3u8PP(self)
                         if fixup_pp.available:
-                            info_dict.setdefault('__postprocessors', [])
                             info_dict['__postprocessors'].append(fixup_pp)
                         else:
                             self.report_warning(
@@ -2254,13 +2327,13 @@ class YoutubeDL(object):
                         assert fixup_policy in ('ignore', 'never')
 
                 try:
-                    self.post_process(filename, info_dict)
+                    self.post_process(dl_filename, info_dict, files_to_move)
                 except (PostProcessingError) as err:
                     self.report_error('postprocessing: %s' % str(err))
                     return
                 try:
                     for ph in self._post_hooks:
-                        ph(filename)
+                        ph(full_filename)
                 except Exception as err:
                     self.report_error('post hooks: %s' % str(err))
                     return
@@ -2326,27 +2399,42 @@ class YoutubeDL(object):
             (k, v) for k, v in info_dict.items()
             if k not in ['requested_formats', 'requested_subtitles'])
 
-    def post_process(self, filename, ie_info):
+    def post_process(self, filename, ie_info, files_to_move={}):
         """Run all the postprocessors on the given file."""
         info = dict(ie_info)
         info['filepath'] = filename
-        pps_chain = []
-        if ie_info.get('__postprocessors') is not None:
-            pps_chain.extend(ie_info['__postprocessors'])
-        pps_chain.extend(self._pps)
-        for pp in pps_chain:
+
+        def run_pp(pp):
             files_to_delete = []
+            infodict = info
             try:
-                files_to_delete, info = pp.run(info)
+                files_to_delete, infodict = pp.run(infodict)
             except PostProcessingError as e:
                 self.report_error(e.msg)
-            if files_to_delete and not self.params.get('keepvideo', False):
+            if not files_to_delete:
+                return infodict
+
+            if self.params.get('keepvideo', False):
+                files_to_move.update(dict((f, '') for f in files_to_delete))
+            else:
                 for old_filename in set(files_to_delete):
                     self.to_screen('Deleting original file %s (pass -k to keep)' % old_filename)
                     try:
                         os.remove(encodeFilename(old_filename))
                     except (IOError, OSError):
                         self.report_warning('Unable to remove downloaded original file')
+                    if old_filename in files_to_move:
+                        del files_to_move[old_filename]
+            return infodict
+
+        for pp in ie_info.get('__postprocessors', []):
+            info = run_pp(pp)
+        for pp in self._pps:
+            info = run_pp(pp)
+        info = run_pp(MoveFilesAfterDownloadPP(self, files_to_move))
+        files_to_move = {}
+        for pp in self._pps_end:
+            info = run_pp(pp)
 
     def _make_archive_id(self, info_dict):
         video_id = info_dict.get('id')
@@ -2700,14 +2788,11 @@ class YoutubeDL(object):
             if thumbnails:
                 thumbnails = [thumbnails[-1]]
         elif self.params.get('write_all_thumbnails', False):
-            thumbnails = info_dict.get('thumbnails')
+            thumbnails = info_dict.get('thumbnails') or []
         else:
-            return
+            thumbnails = []
 
-        if not thumbnails:
-            # No thumbnails present, so return immediately
-            return
-
+        ret = []
         for t in thumbnails:
             thumb_ext = determine_ext(t['url'], 'jpg')
             suffix = '_%s' % t['id'] if len(thumbnails) > 1 else ''
@@ -2715,6 +2800,7 @@ class YoutubeDL(object):
             t['filename'] = thumb_filename = replace_extension(filename + suffix, thumb_ext, info_dict.get('ext'))
 
             if not self.params.get('overwrites', True) and os.path.exists(encodeFilename(thumb_filename)):
+                ret.append(thumb_filename)
                 self.to_screen('[%s] %s: Thumbnail %sis already present' %
                                (info_dict['extractor'], info_dict['id'], thumb_display_id))
             else:
@@ -2724,8 +2810,10 @@ class YoutubeDL(object):
                     uf = self.urlopen(t['url'])
                     with open(encodeFilename(thumb_filename), 'wb') as thumbf:
                         shutil.copyfileobj(uf, thumbf)
+                    ret.append(thumb_filename)
                     self.to_screen('[%s] %s: Writing thumbnail %sto: %s' %
                                    (info_dict['extractor'], info_dict['id'], thumb_display_id, thumb_filename))
                 except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                     self.report_warning('Unable to download thumbnail "%s": %s' %
                                         (t['url'], error_to_compat_str(err)))
+        return ret

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -389,6 +389,7 @@ class YoutubeDL(object):
         self._ies_instances = {}
         self._pps = []
         self._pps_end = []
+        self.__prepare_filename_warned = False
         self._post_hooks = []
         self._progress_hooks = []
         self._download_retcode = 0
@@ -2414,7 +2415,8 @@ class YoutubeDL(object):
                 return infodict
 
             if self.params.get('keepvideo', False):
-                files_to_move.update(dict((f, '') for f in files_to_delete))
+                for f in files_to_delete:
+                    files_to_move.setdefault(f, '')
             else:
                 for old_filename in set(files_to_delete):
                     self.to_screen('Deleting original file %s (pass -k to keep)' % old_filename)
@@ -2426,9 +2428,7 @@ class YoutubeDL(object):
                         del files_to_move[old_filename]
             return infodict
 
-        for pp in ie_info.get('__postprocessors', []):
-            info = run_pp(pp)
-        for pp in self._pps:
+        for pp in ie_info.get('__postprocessors', []) + self._pps:
             info = run_pp(pp)
         info = run_pp(MoveFilesAfterDownloadPP(self, files_to_move))
         files_to_move = {}

--- a/youtube_dlc/YoutubeDL.py
+++ b/youtube_dlc/YoutubeDL.py
@@ -2222,7 +2222,6 @@ class YoutubeDL(object):
                             os.path.splitext(filename)[0]
                             if filename_real_ext == old_ext
                             else filename)
-                        print(filename, filename_real_ext, filename_wo_ext, info_dict['ext'])
                         return '%s.%s' % (filename_wo_ext, info_dict['ext'])
 
                     # Ensure filename always has a correct extension for successful merge

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -358,7 +358,7 @@ def _real_main(argv=None):
     if opts.paths is not None:
         for string in opts.paths:
             path_names = 'home|temp|config|description|annotation|subtitle|infojson|thumbnail'
-            mobj = re.match(r'(?P<name>%s):(?P<path>.*)$' % path_names, string)
+            mobj = re.match(r'(?i)(?P<name>%s):(?P<path>.*)$' % path_names, string)
             if mobj is None:
                 parser.error('invalid path string "%s" given' % string)
             name, path = mobj.group('name').lower(), mobj.group('path').strip()

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -331,18 +331,6 @@ def _real_main(argv=None):
         opts.postprocessor_args.setdefault('sponskrub', [])
         opts.postprocessor_args['default'] = opts.postprocessor_args['default-compat']
 
-    paths = {}
-    if opts.paths is not None:
-        for string in opts.paths:
-            path_names = 'home|temp|config|description|annotation|subtitle|infojson|thumbnail'
-            mobj = re.match(r'(?i)(?P<name>%s):(?P<path>.*)$' % path_names, string)
-            if mobj is None:
-                parser.error('invalid path string "%s" given' % string)
-            name, path = mobj.group('name').lower(), mobj.group('path').strip()
-            if opts.verbose:
-                write_string('[debug] Adding %s path from command line option: %s\n' % (name, path))
-            paths[name] = path
-
     match_filter = (
         None if opts.match_filter is None
         else match_filter_func(opts.match_filter))
@@ -380,7 +368,7 @@ def _real_main(argv=None):
         'listformats': opts.listformats,
         'listformats_table': opts.listformats_table,
         'outtmpl': outtmpl,
-        'paths': paths,
+        'paths': opts.paths,
         'autonumber_size': opts.autonumber_size,
         'autonumber_start': opts.autonumber_start,
         'restrictfilenames': opts.restrictfilenames,

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -18,7 +18,6 @@ from .options import (
 )
 from .compat import (
     compat_getpass,
-    compat_shlex_split,
     workaround_optparse_bug9161,
 )
 from .utils import (
@@ -70,14 +69,7 @@ def _real_main(argv=None):
         std_headers['Referer'] = opts.referer
 
     # Custom HTTP headers
-    if opts.headers is not None:
-        for h in opts.headers:
-            if ':' not in h:
-                parser.error('wrong header formatting, it should be key:value, not "%s"' % h)
-            key, value = h.split(':', 1)
-            if opts.verbose:
-                write_string('[debug] Adding header from command line option %s:%s\n' % (key, value))
-            std_headers[key] = value
+    std_headers.update(opts.headers)
 
     # Dump user agent
     if opts.dump_user_agent:
@@ -334,25 +326,10 @@ def _real_main(argv=None):
             'exec_cmd': opts.exec_cmd,
             '_after_move': True
         })
-    external_downloader_args = None
-    if opts.external_downloader_args:
-        external_downloader_args = compat_shlex_split(opts.external_downloader_args)
 
-    postprocessor_args = {}
-    if opts.postprocessor_args is not None:
-        for string in opts.postprocessor_args:
-            mobj = re.match(r'(?P<pp>\w+(?:\+\w+)?):(?P<args>.*)$', string)
-            if mobj is None:
-                if 'sponskrub' not in postprocessor_args:  # for backward compatibility
-                    postprocessor_args['sponskrub'] = []
-                    if opts.verbose:
-                        write_string('[debug] Adding postprocessor args from command line option sponskrub: \n')
-                pp_key, pp_args = 'default', string
-            else:
-                pp_key, pp_args = mobj.group('pp').lower(), mobj.group('args')
-            if opts.verbose:
-                write_string('[debug] Adding postprocessor args from command line option %s: %s\n' % (pp_key, pp_args))
-            postprocessor_args[pp_key] = compat_shlex_split(pp_args)
+    if 'default-compat' in opts.postprocessor_args and 'default' not in opts.postprocessor_args:
+        opts.postprocessor_args.setdefault('sponskrub', [])
+        opts.postprocessor_args['default'] = opts.postprocessor_args['default-compat']
 
     paths = {}
     if opts.paths is not None:
@@ -499,8 +476,8 @@ def _real_main(argv=None):
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
-        'external_downloader_args': external_downloader_args,
-        'postprocessor_args': postprocessor_args,
+        'external_downloader_args': opts.external_downloader_args,
+        'postprocessor_args': opts.postprocessor_args,
         'cn_verification_proxy': opts.cn_verification_proxy,
         'geo_verification_proxy': opts.geo_verification_proxy,
         'config_location': opts.config_location,

--- a/youtube_dlc/__init__.py
+++ b/youtube_dlc/__init__.py
@@ -252,6 +252,7 @@ def _real_main(argv=None):
         parser.error('Cannot download a video and extract audio into the same'
                      ' file! Use "{0}.%(ext)s" instead of "{0}" as the output'
                      ' template'.format(outtmpl))
+
     for f in opts.format_sort:
         if re.match(InfoExtractor.FormatSort.regex, f) is None:
             parser.error('invalid format sort string "%s" specified' % f)
@@ -326,12 +327,12 @@ def _real_main(argv=None):
             'force': opts.sponskrub_force,
             'ignoreerror': opts.sponskrub is None,
         })
-    # Please keep ExecAfterDownload towards the bottom as it allows the user to modify the final file in any way.
-    # So if the user is able to remove the file before your postprocessor runs it might cause a few problems.
+    # ExecAfterDownload must be the last PP
     if opts.exec_cmd:
         postprocessors.append({
             'key': 'ExecAfterDownload',
             'exec_cmd': opts.exec_cmd,
+            '_after_move': True
         })
     external_downloader_args = None
     if opts.external_downloader_args:
@@ -352,6 +353,18 @@ def _real_main(argv=None):
             if opts.verbose:
                 write_string('[debug] Adding postprocessor args from command line option %s: %s\n' % (pp_key, pp_args))
             postprocessor_args[pp_key] = compat_shlex_split(pp_args)
+
+    paths = {}
+    if opts.paths is not None:
+        for string in opts.paths:
+            path_names = 'home|temp|config|description|annotation|subtitle|infojson|thumbnail'
+            mobj = re.match(r'(?P<name>%s):(?P<path>.*)$' % path_names, string)
+            if mobj is None:
+                parser.error('invalid path string "%s" given' % string)
+            name, path = mobj.group('name').lower(), mobj.group('path').strip()
+            if opts.verbose:
+                write_string('[debug] Adding %s path from command line option: %s\n' % (name, path))
+            paths[name] = path
 
     match_filter = (
         None if opts.match_filter is None
@@ -390,6 +403,7 @@ def _real_main(argv=None):
         'listformats': opts.listformats,
         'listformats_table': opts.listformats_table,
         'outtmpl': outtmpl,
+        'paths': paths,
         'autonumber_size': opts.autonumber_size,
         'autonumber_start': opts.autonumber_start,
         'restrictfilenames': opts.restrictfilenames,

--- a/youtube_dlc/downloader/external.py
+++ b/youtube_dlc/downloader/external.py
@@ -95,7 +95,8 @@ class ExternalFD(FileDownloader):
         return cli_valueless_option(self.params, command_option, param, expected_value)
 
     def _configuration_args(self, default=[]):
-        return cli_configuration_args(self.params, 'external_downloader_args', default)
+        return cli_configuration_args(
+            self.params, 'external_downloader_args', self.get_basename(), default)[0]
 
     def _call_downloader(self, tmpfilename, info_dict):
         """ Either overwrite this or implement _make_cmd """

--- a/youtube_dlc/extractor/cbs.py
+++ b/youtube_dlc/extractor/cbs.py
@@ -59,7 +59,7 @@ class CBSIE(CBSBaseIE):
             'http://can.cbs.com/thunder/player/videoPlayerService.php',
             content_id, query={'partner': site, 'contentId': content_id})
         video_data = xpath_element(items_data, './/item')
-        title = xpath_text(video_data, 'videoTitle', 'title', True)
+        title = xpath_text(video_data, 'videoTitle', 'title') or xpath_text(video_data, 'videotitle', 'title')
         tp_path = 'dJ5BDC/media/guid/%d/%s' % (mpx_acc, content_id)
         tp_release_url = 'http://link.theplatform.com/s/' + tp_path
 

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -41,7 +41,6 @@ def _hide_login_info(opts):
 
 def parseOpts(overrideArguments=None):
     def _readOptions(filename_bytes, default=[]):
-        print(filename_bytes)
         try:
             optionf = open(filename_bytes)
         except IOError:

--- a/youtube_dlc/options.py
+++ b/youtube_dlc/options.py
@@ -820,8 +820,12 @@ def parseOpts(overrideArguments=None):
         '--id', default=False,
         action='store_true', dest='useid', help=optparse.SUPPRESS_HELP)
     filesystem.add_option(
-        '-P', '--paths', metavar='TYPE:PATH',
-        dest='paths', action='append',
+        '-P', '--paths',
+        metavar='TYPE:PATH', dest='paths', default={}, type='str',
+        action='callback', callback=_dict_from_multiple_values_options_callback,
+        callback_kwargs={
+            'allowed_keys': 'home|temp|config|description|annotation|subtitle|infojson|thumbnail',
+            'process': lambda x: x.strip()},
         help=(
             'The paths where the files should be downloaded. '
             'Specify the type of file and the path separated by a colon ":" '
@@ -1231,12 +1235,7 @@ def parseOpts(overrideArguments=None):
 
             def get_home_path():
                 opts = parser.parse_args(configs['portable'] + configs['custom'] + configs['command-line'])[0]
-                if opts.paths is None:
-                    return ''
-                for string in opts.paths[::-1]:
-                    if string[:5] == 'home:':
-                        return expand_path(string[5:]).strip()
-                return ''
+                return expand_path(opts.paths.get('home', '')).strip()
 
             configs['home'], paths['home'] = read_options(get_home_path())
             if '--ignore-config' in configs['home']:

--- a/youtube_dlc/postprocessor/__init__.py
+++ b/youtube_dlc/postprocessor/__init__.py
@@ -17,6 +17,7 @@ from .ffmpeg import (
 from .xattrpp import XAttrMetadataPP
 from .execafterdownload import ExecAfterDownloadPP
 from .metadatafromtitle import MetadataFromTitlePP
+from .movefilesafterdownload import MoveFilesAfterDownloadPP
 from .sponskrub import SponSkrubPP
 
 
@@ -39,6 +40,7 @@ __all__ = [
     'FFmpegVideoConvertorPP',
     'FFmpegVideoRemuxerPP',
     'MetadataFromTitlePP',
+    'MoveFilesAfterDownloadPP',
     'SponSkrubPP',
     'XAttrMetadataPP',
 ]

--- a/youtube_dlc/postprocessor/common.py
+++ b/youtube_dlc/postprocessor/common.py
@@ -4,8 +4,9 @@ import os
 
 from ..compat import compat_str
 from ..utils import (
-    PostProcessingError,
+    cli_configuration_args,
     encodeFilename,
+    PostProcessingError,
 )
 
 
@@ -91,39 +92,10 @@ class PostProcessor(object):
             self.report_warning(errnote)
 
     def _configuration_args(self, default=[], exe=None):
-        args = self.get_param('postprocessor_args', {})
-        pp_key = self.pp_key().lower()
-
-        if isinstance(args, (list, tuple)):  # for backward compatibility
-            return default if pp_key == 'sponskrub' else args
-        if args is None:
-            return default
-        assert isinstance(args, dict)
-
-        exe_args = None
-        if exe is not None:
-            assert isinstance(exe, compat_str)
-            exe = exe.lower()
-            specific_args = args.get('%s+%s' % (pp_key, exe))
-            if specific_args is not None:
-                assert isinstance(specific_args, (list, tuple))
-                return specific_args
-            exe_args = args.get(exe)
-
-        pp_args = args.get(pp_key) if pp_key != exe else None
-        if pp_args is None and exe_args is None:
-            default = args.get('default', default)
-            assert isinstance(default, (list, tuple))
-            return default
-
-        if pp_args is None:
-            pp_args = []
-        elif exe_args is None:
-            exe_args = []
-
-        assert isinstance(pp_args, (list, tuple))
-        assert isinstance(exe_args, (list, tuple))
-        return pp_args + exe_args
+        key = self.pp_key().lower()
+        args, is_compat = cli_configuration_args(
+            self._downloader.params, 'postprocessor_args', key, default, exe)
+        return args if not is_compat or key != 'sponskrub' else default
 
 
 class AudioConversionError(PostProcessingError):

--- a/youtube_dlc/postprocessor/movefilesafterdownload.py
+++ b/youtube_dlc/postprocessor/movefilesafterdownload.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+import os
+import shutil
+
+from .common import PostProcessor
+from ..utils import (
+    encodeFilename,
+    make_dir,
+    PostProcessingError,
+)
+from ..compat import compat_str
+
+
+class MoveFilesAfterDownloadPP(PostProcessor):
+
+    def __init__(self, downloader, files_to_move):
+        PostProcessor.__init__(self, downloader)
+        self.files_to_move = files_to_move
+
+    @classmethod
+    def pp_key(cls):
+        return 'MoveFiles'
+
+    def run(self, info):
+        if info.get('__dl_filename') is None:
+            return [], info
+        self.files_to_move.setdefault(info['__dl_filename'], '')
+        outdir = os.path.dirname(os.path.abspath(encodeFilename(info['__final_filename'])))
+
+        for oldfile, newfile in self.files_to_move.items():
+            if not os.path.exists(encodeFilename(oldfile)):
+                self.write_debug('File "%s" cannot be found' % oldfile)
+                continue
+            if not newfile:
+                newfile = compat_str(os.path.join(outdir, os.path.basename(encodeFilename(oldfile))))
+            if os.path.abspath(encodeFilename(oldfile)) == os.path.abspath(encodeFilename(newfile)):
+                continue
+            if os.path.exists(encodeFilename(newfile)):
+                if self.get_param('overwrites', True):
+                    self.write_debug('Replacing existing file "%s"' % newfile)
+                    os.path.remove(encodeFilename(newfile))
+                else:
+                    self.report_warning(
+                        'Cannot move file "%s" out of temporary directory since "%s" already exists. '
+                        % (oldfile, newfile))
+                    continue
+            make_dir(newfile, PostProcessingError)
+            self.write_debug('Moving file "%s" to "%s"' % (oldfile, newfile))
+            shutil.move(oldfile, newfile)  # os.rename cannot move between volumes
+
+        info['filepath'] = info['__final_filename']
+        return [], info

--- a/youtube_dlc/postprocessor/movefilesafterdownload.py
+++ b/youtube_dlc/postprocessor/movefilesafterdownload.py
@@ -29,7 +29,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
 
         for oldfile, newfile in self.files_to_move.items():
             if not os.path.exists(encodeFilename(oldfile)):
-                self.write_debug('File "%s" cannot be found' % oldfile)
+                self.report_warning('File "%s" cannot be found' % oldfile)
                 continue
             if not newfile:
                 newfile = compat_str(os.path.join(outdir, os.path.basename(encodeFilename(oldfile))))
@@ -37,7 +37,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
                 continue
             if os.path.exists(encodeFilename(newfile)):
                 if self.get_param('overwrites', True):
-                    self.write_debug('Replacing existing file "%s"' % newfile)
+                    self.report_warning('Replacing existing file "%s"' % newfile)
                     os.path.remove(encodeFilename(newfile))
                 else:
                     self.report_warning(
@@ -45,7 +45,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
                         % (oldfile, newfile))
                     continue
             make_dir(newfile, PostProcessingError)
-            self.write_debug('Moving file "%s" to "%s"' % (oldfile, newfile))
+            self.to_screen('Moving file "%s" to "%s"' % (oldfile, newfile))
             shutil.move(oldfile, newfile)  # os.rename cannot move between volumes
 
         info['filepath'] = info['__final_filename']

--- a/youtube_dlc/utils.py
+++ b/youtube_dlc/utils.py
@@ -5863,3 +5863,15 @@ def clean_podcast_url(url):
                 st\.fm # https://podsights.com/docs/
             )/e
         )/''', '', url)
+
+
+def make_dir(path, to_screen=None):
+    try:
+        dn = os.path.dirname(path)
+        if dn and not os.path.exists(dn):
+            os.makedirs(dn)
+        return True
+    except (OSError, IOError) as err:
+        if callable(to_screen) is not None:
+            to_screen('unable to create directory ' + error_to_compat_str(err))
+        return False

--- a/youtube_dlc/utils.py
+++ b/youtube_dlc/utils.py
@@ -4656,12 +4656,35 @@ def cli_valueless_option(params, command_option, param, expected_value=True):
     return [command_option] if param == expected_value else []
 
 
-def cli_configuration_args(params, param, default=[]):
-    ex_args = params.get(param)
-    if ex_args is None:
-        return default
-    assert isinstance(ex_args, list)
-    return ex_args
+def cli_configuration_args(params, arg_name, key, default=[], exe=None):  # returns arg, for_compat
+    argdict = params.get(arg_name, {})
+    if isinstance(argdict, (list, tuple)):  # for backward compatibility
+        return argdict, True
+
+    if argdict is None:
+        return default, False
+    assert isinstance(argdict, dict)
+
+    assert isinstance(key, compat_str)
+    key = key.lower()
+
+    args = exe_args = None
+    if exe is not None:
+        assert isinstance(exe, compat_str)
+        exe = exe.lower()
+        args = argdict.get('%s+%s' % (key, exe))
+        if args is None:
+            exe_args = argdict.get(exe)
+
+    if args is None:
+        args = argdict.get(key) if key != exe else None
+    if args is None and exe_args is None:
+        args = argdict.get('default', default)
+
+    args, exe_args = args or [], exe_args or []
+    assert isinstance(args, (list, tuple))
+    assert isinstance(exe_args, (list, tuple))
+    return args + exe_args, False
 
 
 class ISO639Utils(object):


### PR DESCRIPTION
```
    -P, --paths TYPE:PATH            The paths where the files should be
                                     downloaded. Specify the type of file and
                                     the path separated by a colon ":"
                                     (supported: description|annotation|subtitle
                                     |infojson|thumbnail). Additionally, you can
                                     also provide "home" and "temp" paths. All
                                     intermediary files are first downloaded to
                                     the temp path and then the final files are
                                     moved over to the home path after download
                                     is finished. Note that this option is
                                     ignored if --output is an absolute path
```

Also, configuration files `yt-dlp.conf` or `youtube-dlc.conf` are now additionally loaded from the home path given by `-P "home:<path>"`, or from the current directory if no such path is given

Eg:

    -P "home:D:\YTDL" -P "temp:C:\temp" -P "description:desc" -P "subtitle:subs" -P "infojson:info" -P "thumbnail:thumbs" -o "%(uploader)s\%(title)s.%(ext)s"

will download:
* Video to: `D:\YTDL\uploader`
* Temp files to: `C:\temp`
* Subtitles to: `D:\YTDL\subs\uploader`
etc

Closes #27 

---

~~There are so many small interconnecting pieces of code that makes this work. Due to that, the chances of some mistake being made are quite large. I would really appreciate if someone is willing to review this code.~~

If I don't get any reviews, I will merge this only after daily driving it for a few days