### PR TITLE
Fix HLS AES-128 with multiple keys in external downloaders

### DIFF
--- a/youtube_dlc/downloader/external.py
+++ b/youtube_dlc/downloader/external.py
@@ -128,6 +128,8 @@ class ExternalFD(FileDownloader):
                 file_list.append(tmpsegmentname)
             if 'key_list' in info_dict:
                 key_list = info_dict['key_list']
+            else:
+                key_list = None
             decrypt_info = None
             dest, _ = sanitize_open(tmpfilename, 'wb')
             for [i, file] in enumerate(file_list):

--- a/youtube_dlc/downloader/external.py
+++ b/youtube_dlc/downloader/external.py
@@ -126,11 +126,14 @@ class ExternalFD(FileDownloader):
             for [i, url] in enumerate(info_dict['url_list']):
                 tmpsegmentname = '%s_%s.frag' % (tmpfilename, i)
                 file_list.append(tmpsegmentname)
+            if 'key_list' in info_dict:
+                key_list = info_dict['key_list']
+            decrypt_info = None
             dest, _ = sanitize_open(tmpfilename, 'wb')
-            for i in file_list:
-                src, _ = sanitize_open(i, 'rb')
-                if 'decrypt_info' in info_dict:
-                    decrypt_info = info_dict['decrypt_info']
+            for [i, file] in enumerate(file_list):
+                src, _ = sanitize_open(file, 'rb')
+                if key_list:
+                    decrypt_info = next((x for x in key_list if x['INDEX'] == i), decrypt_info)
                     if decrypt_info['METHOD'] == 'AES-128':
                         iv = decrypt_info.get('IV')
                         decrypt_info['KEY'] = decrypt_info.get('KEY') or self.ydl.urlopen(

--- a/youtube_dlc/downloader/external.py
+++ b/youtube_dlc/downloader/external.py
@@ -132,7 +132,7 @@ class ExternalFD(FileDownloader):
                 key_list = None
             decrypt_info = None
             dest, _ = sanitize_open(tmpfilename, 'wb')
-            for [i, file] in enumerate(file_list):
+            for i, file in enumerate(file_list):
                 src, _ = sanitize_open(file, 'rb')
                 if key_list:
                     decrypt_info = next((x for x in key_list if x['INDEX'] == i), decrypt_info)

--- a/youtube_dlc/downloader/external.py
+++ b/youtube_dlc/downloader/external.py
@@ -126,10 +126,7 @@ class ExternalFD(FileDownloader):
             for [i, url] in enumerate(info_dict['url_list']):
                 tmpsegmentname = '%s_%s.frag' % (tmpfilename, i)
                 file_list.append(tmpsegmentname)
-            if 'key_list' in info_dict:
-                key_list = info_dict['key_list']
-            else:
-                key_list = None
+            key_list = info_dict.get('key_list')
             decrypt_info = None
             dest, _ = sanitize_open(tmpfilename, 'wb')
             for i, file in enumerate(file_list):

--- a/youtube_dlc/downloader/hls.py
+++ b/youtube_dlc/downloader/hls.py
@@ -134,6 +134,7 @@ class HlsFD(FragmentFD):
         i = 0
         media_sequence = 0
         decrypt_info = {'METHOD': 'NONE'}
+        key_list = []
         byte_range = {}
         frag_index = 0
         ad_frag_next = False
@@ -215,6 +216,10 @@ class HlsFD(FragmentFD):
                             decrypt_info['URI'] = update_url_query(decrypt_info['URI'], extra_query)
                         if decrypt_url != decrypt_info['URI']:
                             decrypt_info['KEY'] = None
+                    key_data = decrypt_info.copy()
+                    key_data['INDEX'] = frag_index
+                    key_list.append(key_data)
+
                 elif line.startswith('#EXT-X-MEDIA-SEQUENCE'):
                     media_sequence = int(line[22:])
                 elif line.startswith('#EXT-X-BYTERANGE'):
@@ -232,7 +237,7 @@ class HlsFD(FragmentFD):
         if real_downloader:
             info_copy = info_dict.copy()
             info_copy['url_list'] = fragment_urls
-            info_copy['decrypt_info'] = decrypt_info
+            info_copy['key_list'] = key_list
             fd = real_downloader(self.ydl, self.params)
             # TODO: Make progress updates work without hooking twice
             # for ph in self._progress_hooks:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/pukkandan/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes AES-128 support in external downloaders when multiple keys are used.

Multiple key example: https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8
Single key example: https://www.cartoonnetwork.com/video/bakugan/the-mysterious-revengerwynton-vs-lia-episode.html