### PR TITLE
use new POST API for live chat

### DIFF
--- a/youtube_dlc/downloader/fragment.py
+++ b/youtube_dlc/downloader/fragment.py
@@ -95,11 +95,12 @@ class FragmentFD(FileDownloader):
         frag_index_stream.write(json.dumps({'downloader': downloader}))
         frag_index_stream.close()
 
-    def _download_fragment(self, ctx, frag_url, info_dict, headers=None):
+    def _download_fragment(self, ctx, frag_url, info_dict, headers=None, request_data=None):
         fragment_filename = '%s-Frag%d' % (ctx['tmpfilename'], ctx['fragment_index'])
         fragment_info_dict = {
             'url': frag_url,
             'http_headers': headers or info_dict.get('http_headers'),
+            'request_data': request_data,
         }
         success = ctx['dl'].download(fragment_filename, fragment_info_dict)
         if not success:

--- a/youtube_dlc/downloader/http.py
+++ b/youtube_dlc/downloader/http.py
@@ -27,6 +27,7 @@ from ..utils import (
 class HttpFD(FileDownloader):
     def real_download(self, filename, info_dict):
         url = info_dict['url']
+        request_data = info_dict.get('request_data', None)
 
         class DownloadContext(dict):
             __getattr__ = dict.get
@@ -101,7 +102,7 @@ class HttpFD(FileDownloader):
                 range_end = ctx.data_len - 1
             has_range = range_start is not None
             ctx.has_range = has_range
-            request = sanitized_Request(url, None, headers)
+            request = sanitized_Request(url, request_data, headers)
             if has_range:
                 set_range(request, range_start, range_end)
             # Establish connection
@@ -152,7 +153,7 @@ class HttpFD(FileDownloader):
                     try:
                         # Open the connection again without the range header
                         ctx.data = self.ydl.urlopen(
-                            sanitized_Request(url, None, headers))
+                            sanitized_Request(url, request_data, headers))
                         content_length = ctx.data.info()['Content-Length']
                     except (compat_urllib_error.HTTPError, ) as err:
                         if err.code < 500 or err.code >= 600:

--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -2,7 +2,6 @@ from __future__ import division, unicode_literals
 
 import re
 import json
-import copy
 
 from .fragment import FragmentFD
 from ..compat import compat_urllib_error
@@ -36,7 +35,7 @@ class YoutubeLiveChatReplayFD(FragmentFD):
         def dl_fragment(url, data=None, headers=None):
             http_headers = info_dict.get('http_headers', {})
             if headers:
-                http_headers = copy.deepcopy(http_headers)
+                http_headers = http_headers.copy()
                 http_headers.update(headers)
             return self._download_fragment(ctx, url, info_dict, http_headers, data)
 

--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -1,6 +1,5 @@
 from __future__ import division, unicode_literals
 
-import re
 import json
 
 from .fragment import FragmentFD

--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -2,6 +2,7 @@ from __future__ import division, unicode_literals
 
 import re
 import json
+import copy
 
 from .fragment import FragmentFD
 from ..compat import compat_urllib_error
@@ -30,7 +31,8 @@ class YoutubeLiveChatReplayFD(FragmentFD):
         def dl_fragment(url, data=None, headers=None):
             http_headers = info_dict.get('http_headers', {})
             if headers:
-                http_headers = {**http_headers, **headers}
+                http_headers = copy.deepcopy(http_headers)
+                http_headers.update(headers)
             return self._download_fragment(ctx, url, info_dict, http_headers, data)
 
         def parse_yt_initial_data(data):
@@ -127,7 +129,7 @@ class YoutubeLiveChatReplayFD(FragmentFD):
         while continuation_id is not None:
             frag_index += 1
             request_data = {
-                'context': {**innertube_context},
+                'context': innertube_context,
                 'continuation': continuation_id,
             }
             if frag_index > 1:

--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -50,19 +50,7 @@ class YoutubeLiveChatReplayFD(FragmentFD):
                     except RegexNotFoundError:
                         data = None
                     if not data:
-                        data = {}
-                        raw_data = json.loads(raw_fragment)
-                        # sometimes youtube replies with a list
-                        if not isinstance(raw_data, list):
-                            raw_data = [raw_data]
-                        for item in raw_data:
-                            # data is sometimes behind 'response'
-                            if 'response' in item:
-                                data = item['response']
-                            else:
-                                data = item
-                            break
-
+                        data = json.loads(raw_fragment)
                     live_chat_continuation = try_get(
                         data,
                         lambda x: x['continuationContents']['liveChatContinuation'], dict) or {}

--- a/youtube_dlc/downloader/youtube_live_chat.py
+++ b/youtube_dlc/downloader/youtube_live_chat.py
@@ -30,7 +30,7 @@ class YoutubeLiveChatReplayFD(FragmentFD):
             'total_frags': None,
         }
 
-        ie = YT_BaseIE(self)
+        ie = YT_BaseIE(self.ydl)
 
         def dl_fragment(url, data=None, headers=None):
             http_headers = info_dict.get('http_headers', {})


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/pukkandan/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Attempts to fix https://github.com/pukkandan/yt-dlp/issues/82.

YouTube has removed support for the old GET based live chat API, and it's now returning 404 for all videos that I tested.

The new API needs `INNERTUBE_CONTEXT` and `INNERTUBE_API_KEY` from ytcfg, so the regex for that is copied from main extractor. I couldn't find a cleaner way to do it.