### PR TITLE
[niconico] Support metadata 'channel' and 'channel_id' (fix #77).

### DIFF
--- a/youtube_dlc/extractor/niconico.py
+++ b/youtube_dlc/extractor/niconico.py
@@ -547,14 +547,14 @@ class NiconicoIE(InfoExtractor):
         webpage_url = get_video_info_web('watch_url') or url
 
         # for channel movie and community movie
-        channel_id = (
-            try_get(api_data, lambda x: x['channel']['globalId'])
-            or try_get(api_data, lambda x: x['community']['globalId'])
-        )
-        channel = (
-            try_get(api_data, lambda x: x['channel']['name'])
-            or try_get(api_data, lambda x: x['community']['name'])
-        )
+        channel_id = try_get(
+            api_data,
+            (lambda x: x['channel']['globalId'],
+             lambda x: x['community']['globalId']))
+        channel = try_get(
+            api_data,
+            (lambda x: x['channel']['name'],
+             lambda x: x['community']['name']))
 
         # Note: cannot use api_data.get('owner', {}) because owner may be set to "null"
         # in the JSON, which will cause None to be returned instead of {}.

--- a/youtube_dlc/extractor/niconico.py
+++ b/youtube_dlc/extractor/niconico.py
@@ -546,11 +546,29 @@ class NiconicoIE(InfoExtractor):
 
         webpage_url = get_video_info_web('watch_url') or url
 
+        # for channel movie and community movie
+        channel_id = (
+            try_get(api_data, lambda x: x['channel']['globalId'])
+            or try_get(api_data, lambda x: x['community']['globalId'])
+        )
+        channel = (
+            try_get(api_data, lambda x: x['channel']['name'])
+            or try_get(api_data, lambda x: x['community']['name'])
+        )
+
         # Note: cannot use api_data.get('owner', {}) because owner may be set to "null"
         # in the JSON, which will cause None to be returned instead of {}.
         owner = try_get(api_data, lambda x: x.get('owner'), dict) or {}
-        uploader_id = get_video_info_web(['ch_id', 'user_id']) or owner.get('id')
-        uploader = get_video_info_web(['ch_name', 'user_nickname']) or owner.get('nickname')
+        uploader_id = (
+            get_video_info_web(['ch_id', 'user_id'])
+            or owner.get('id')
+            or channel_id
+        )
+        uploader = (
+            get_video_info_web(['ch_name', 'user_nickname'])
+            or owner.get('nickname')
+            or channel
+        )
 
         return {
             'id': video_id,
@@ -561,6 +579,8 @@ class NiconicoIE(InfoExtractor):
             'uploader': uploader,
             'timestamp': timestamp,
             'uploader_id': uploader_id,
+            'channel': channel,
+            'channel_id': channel_id,
             'view_count': view_count,
             'comment_count': comment_count,
             'duration': duration,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/pukkandan/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

For channel movies and community only movies in niconico douga, support metadata 'channel', 'channel_id', 'uploader' and 'uploader_id'.
In other words, fix #77.